### PR TITLE
add cvc in paygent when create and auth credict card

### DIFF
--- a/credit_card.go
+++ b/credit_card.go
@@ -23,6 +23,7 @@ var Brands = map[string]*regexp.Regexp{
 type SavedCreditCard struct {
 	CustomerID   string
 	CreditCardID string
+	CVC      string
 }
 
 type CreditCard struct {

--- a/gateways/paygent/credit_card.go
+++ b/gateways/paygent/credit_card.go
@@ -30,13 +30,18 @@ func (paygent *Paygent) CreateCreditCard(creditCardParams gomerchant.CreateCredi
 		brand, _   = brandsMap[creditCard.Brand()]
 	)
 
-	results, err := paygent.Request("025", gomerchant.Params{
+	params := gomerchant.Params{
 		"customer_id":     creditCardParams.CustomerID,
 		"card_number":     creditCard.Number,
 		"card_valid_term": getValidTerm(creditCard),
 		"cardholder_name": creditCard.Name,
 		"card_brand":      brand,
-	}.IgnoreBlankFields())
+	}.IgnoreBlankFields()
+	if paygent.Config.SecurityCodeUse {
+		params.Set("security_code_use",1)
+		params.Set("card_conf_number",creditCard.CVC)
+	}
+	results, err := paygent.Request("025", params)
 
 	if err == nil {
 		if customerCardID, ok := results.Get("customer_card_id"); ok {

--- a/gateways/paygent/paygent_test.go
+++ b/gateways/paygent/paygent_test.go
@@ -2,11 +2,11 @@ package paygent_test
 
 import (
 	"fmt"
+	"github.com/jinzhu/configor"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/jinzhu/configor"
 	"github.com/qor/gomerchant"
 	"github.com/qor/gomerchant/gateways/paygent"
 	"github.com/qor/gomerchant/tests"
@@ -25,15 +25,16 @@ type Config struct {
 	CAFilePath     string `required:"true" default:"curl-ca-bundle.crt"`
 
 	ProductionMode bool
+	SecurityCodeUse bool
 }
 
 func init() {
-	var config = &Config{}
-	os.Setenv("CONFIGOR_ENV_PREFIX", "-")
-	if err := configor.Load(config); err != nil {
-		fmt.Println(err)
+	var config  = &Config{}
+	if err := configor.New(&configor.Config{ENVPrefix: "PAYGENT_CONFIG"}).Load(config); err != nil {
+		fmt.Println(config)
 		os.Exit(1)
 	}
+
 
 	Paygent = paygent.New(&paygent.Config{
 		MerchantID:      config.MerchantID,
@@ -43,6 +44,7 @@ func init() {
 		CertPassword:    config.CertPassword,
 		CAFilePath:      config.CAFilePath,
 		ProductionMode:  config.ProductionMode,
+		SecurityCodeUse: config.SecurityCodeUse,
 	})
 }
 
@@ -78,6 +80,7 @@ func Test3DAuthorizeAndCapture(t *testing.T) {
 						Number:   card,
 						ExpMonth: 1,
 						ExpYear:  uint(time.Now().Year() + 1),
+						CVC: "1234",
 					},
 				},
 			})


### PR DESCRIPTION
To increase the securities to create the credit card and pay by credit card.
You could set config`SecurityCodeUse=true` 
What's more, when you want to create a credit card, you have to set CVC in CreditCard